### PR TITLE
docs(README): Fix Supranim repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Key Features
 - Compiled, fast and lightweight with a small memory footprint
-- Built on top of the [Supranim web framework](https://github.com/supranin/supranim)
+- Built on top of the [Supranim web framework](https://github.com/supranim/supranim)
 - Posts, pages, comments, categories and tags
 - User authentication and management
 - Media management with file uploads


### PR DESCRIPTION
- Correct GitHub organization name from 'supranin' to 'supranim' in framework link
- Ensures documentation points to the correct upstream repository